### PR TITLE
typo fixes and _throughput temporarily removed

### DIFF
--- a/src/pyre.cc
+++ b/src/pyre.cc
@@ -24,7 +24,6 @@ Pyre::Pyre(cyclus::Context* ctx)
         rf = &ref;
         Winning win = Winning(winning_current, winning_time, winning_flowrate, winning_volume);
         w = &win;
-        double _throughput = throughput;
       }
 
 cyclus::Inventories Pyre::SnapshotInv() {
@@ -374,4 +373,4 @@ extern "C" cyclus::Agent* ConstructPyre(cyclus::Context* ctx) {
   return new Pyre(ctx);
 }
 
-}  // namespace cycamore
+}  // namespace recycle

--- a/src/pyre.h
+++ b/src/pyre.h
@@ -211,7 +211,7 @@ class Pyre
   "range": [1,3], \
   "uilabel": "Reduction Li2O wt%", \
   }
-  double reduct_li2o;
+  double reduct_lithium_oxide;
 
   #pragma cyclus var { \
   "doc": "Volume of the Electroreduction Chamber", \


### PR DESCRIPTION
throughput accomplishes the same thing "_throughput" is redundant, also corrected mismatched variable name.

This closes issue #5 