### PR TITLE
Issue7

### DIFF
--- a/input/pride.xml
+++ b/input/pride.xml
@@ -1,6 +1,6 @@
 <simulation>
   <control>
-    <duration>10</duration>
+    <duration>20</duration>
     <startmonth>1</startmonth>
     <startyear>2000</startyear>
   </control>

--- a/input/pride.xml
+++ b/input/pride.xml
@@ -9,8 +9,8 @@
     <spec><lib>agents</lib><name>NullRegion</name></spec>
     <spec><lib>agents</lib><name>NullInst</name></spec>
     <spec><lib>cycamore</lib><name>Source</name></spec>
-    <spec><lib>recycle</lib><name>Pyre</name></spec>
     <spec><lib>cycamore</lib><name>DeployInst</name></spec>
+    <spec><lib>recycle</lib><name>Pyre</name></spec>
   </archetypes>
 
   <facility>

--- a/input/pride.xml
+++ b/input/pride.xml
@@ -35,7 +35,7 @@
         <volox_time>1</volox_time>
         <volox_flowrate>2</volox_flowrate>
         <volox_volume>1</volox_volume>
-        <reduct_current>4</reduct_current>
+        <reduct_current>8</reduct_current>
         <reduct_lithium_oxide>2</reduct_lithium_oxide>
         <reduct_volume>1</reduct_volume>
         <reduct_time>2</reduct_time>
@@ -44,7 +44,7 @@
         <refine_rotation>100</refine_rotation>
         <refine_batch_size>30</refine_batch_size>
         <refine_time>2</refine_time>
-        <winning_current>5</winning_current>
+        <winning_current>8</winning_current>
         <winning_time>1</winning_time>
         <winning_flowrate>3</winning_flowrate>
         <winning_volume>2</winning_volume>
@@ -129,7 +129,7 @@
             </info>
           </item>
           <item>
-            <commod>U_prod</commod>
+            <commod>refine_U_prod</commod>
             <info>
               <buf_size>1000</buf_size>
               <efficiencies>
@@ -140,7 +140,7 @@
             </info>
           </item>
           <item>
-            <commod>TRU_prod</commod>
+            <commod>refine_TRU_prod</commod>
             <info>
               <buf_size>1000</buf_size>
               <efficiencies>

--- a/src/pyre.cc
+++ b/src/pyre.cc
@@ -17,6 +17,7 @@ Pyre::Pyre(cyclus::Context* ctx)
       latitude(0.0),
       longitude(0.0),
       coordinates(latitude, longitude) {
+        
       }
 
 cyclus::Inventories Pyre::SnapshotInv() {
@@ -129,16 +130,14 @@ void Pyre::Tick() {
   std::map<std::string, Material::Ptr> stagedsep;
   Record("Separating", orig_qty, "UNF");
   RecordStreams();
-  int stream_count = 1;
   for (it = streams_.begin(); it != streams_.end(); ++it) {
     Stream info = it->second;
     std::string name = it->first;
-    stagedsep[name] = Separate(name, info, stream_count, mat);
+    stagedsep[name] = Separate(name, info, mat);
     double frac = streambufs[name].space() / stagedsep[name]->quantity();
     if (frac < maxfrac) {
       maxfrac = frac;
     }
-    stream_count++;
   }
 
   std::map<std::string, Material::Ptr>::iterator itf;
@@ -168,7 +167,7 @@ void Pyre::Tick() {
 }
  
 Material::Ptr Pyre::Separate(std::string name, Stream stream, 
-  int stream_count, Material::Ptr mat) {
+  Material::Ptr mat) {
   Material::Ptr material;
   if (name.find("volox") != std::string::npos) {
     material = v.VoloxSepMaterial(stream.second, mat);

--- a/src/pyre.cc
+++ b/src/pyre.cc
@@ -1,4 +1,5 @@
 #include "pyre.h"
+#include "cyclus.h"
 
 using cyclus::Material;
 using cyclus::Composition;
@@ -133,6 +134,7 @@ void Pyre::Tick() {
   for (it = streams_.begin(); it != streams_.end(); ++it) {
     Stream info = it->second;
     std::string name = it->first;
+    Record("Blah", orig_qty, "U235");
     stagedsep[name] = Separate(info, stream_count, mat);
     double frac = streambufs[name].space() / stagedsep[name]->quantity();
     if (frac < maxfrac) {
@@ -167,22 +169,24 @@ void Pyre::Tick() {
   }
 }
  
-Material::Ptr Pyre::Separate(Stream stream, int stream_count, 
-  Material::Ptr mat) {
-  Material::Ptr sep;
+Material::Ptr Pyre::Separate(Stream stream, int stream_count, Material::Ptr mat) {
+  Material::Ptr material;
   switch (stream_count) {
-    if (stream_count == 1) {
-      sep = v->VoloxSepMaterial(stream.second, mat);
-      Record("Test", sep->quantity(), "VOLOX");
-      } else if (stream_count == 2) {
-      sep = rd->ReductSepMaterial(stream.second, mat);
-      } else if (stream_count == 3 || stream_count == 4) {
-      sep = rf->RefineSepMaterial(stream.second, mat);
-      } else {
-      sep = w->WinningSepMaterial(stream.second, mat);
-      }
+    case 1:
+      material = v->VoloxSepMaterial(stream.second, mat);
+      break;
+    case 2:
+      material = rd->ReductSepMaterial(stream.second, mat);
+      break;
+    case 3:
+    case 4:
+      material = rf->RefineSepMaterial(stream.second, mat);
+      break;
+    case 5:
+      material = w->WinningSepMaterial(stream.second, mat);
+      break;
   }
-  return sep;
+  return material;
 }
 
 

--- a/src/pyre.cc
+++ b/src/pyre.cc
@@ -55,16 +55,16 @@ typedef std::map<std::string, Stream> StreamSet;
 void Pyre::EnterNotify() {
   Volox vol = Volox(volox_temp, volox_time, volox_flowrate, 
           volox_volume);
-        v = vol;
+        v = &vol;
         Reduct red = Reduct(reduct_current, reduct_lithium_oxide, 
           reduct_volume, reduct_time);
-        rd = red;
+        rd = &red;
         Refine ref = Refine(refine_temp, refine_press, refine_rotation, 
           refine_batch_size, refine_time);
-        rf = ref;
+        rf = &ref;
         Winning win = Winning(winning_current, winning_time, winning_flowrate, 
           winning_volume);
-        w = win;
+        w = &win;
   cyclus::Facility::EnterNotify();
   std::map<int, double> efficiency_;
 

--- a/src/pyre.cc
+++ b/src/pyre.cc
@@ -20,21 +20,7 @@ Pyre::Pyre(cyclus::Context* ctx)
       }
 
 cyclus::Inventories Pyre::SnapshotInv() {
-  cyclus::Inventories invs;
-  std::cout << "Volox Temp = " << volox_temp << std::endl;
-
-        Volox vol = Volox(volox_temp, volox_time, volox_flowrate, 
-          volox_volume);
-        v = &vol;
-        Reduct red = Reduct(reduct_current, reduct_lithium_oxide, 
-          reduct_volume, reduct_time);
-        rd = &red;
-        Refine ref = Refine(refine_temp, refine_press, refine_rotation, 
-          refine_batch_size, refine_time);
-        rf = &ref;
-        Winning win = Winning(winning_current, winning_time, winning_flowrate, 
-          winning_volume);
-        w = &win;  
+  cyclus::Inventories invs;  
 
   // these inventory names are intentionally convoluted so as to not clash
   // with the user-specified stream commods that are used as the separations
@@ -67,6 +53,18 @@ typedef std::pair<double, std::map<int, double> > Stream;
 typedef std::map<std::string, Stream> StreamSet;
 
 void Pyre::EnterNotify() {
+  Volox vol = Volox(volox_temp, volox_time, volox_flowrate, 
+          volox_volume);
+        v = vol;
+        Reduct red = Reduct(reduct_current, reduct_lithium_oxide, 
+          reduct_volume, reduct_time);
+        rd = red;
+        Refine ref = Refine(refine_temp, refine_press, refine_rotation, 
+          refine_batch_size, refine_time);
+        rf = ref;
+        Winning win = Winning(winning_current, winning_time, winning_flowrate, 
+          winning_volume);
+        w = win;
   cyclus::Facility::EnterNotify();
   std::map<int, double> efficiency_;
 
@@ -135,8 +133,8 @@ void Pyre::Tick() {
   for (it = streams_.begin(); it != streams_.end(); ++it) {
     Stream info = it->second;
     std::string name = it->first;
+    std::cout << "Stream number " << stream_count << std::endl;
     stagedsep[name] = Separate(info, stream_count, mat);
-    std::cout << "hi" << std::endl;
     Record("Placeholder", stagedsep[name]->quantity(), name);
     double frac = streambufs[name].space() / stagedsep[name]->quantity();
     if (frac < maxfrac) {
@@ -155,7 +153,7 @@ void Pyre::Tick() {
       Record("Separated", m->quantity() * maxfrac, name);
     }
   }
-
+  std::cout << "test" << std::endl;
   if (maxfrac == 1) {
     if (mat->quantity() > 0) {
       // unspecified separations fractions go to leftovers
@@ -175,18 +173,18 @@ Material::Ptr Pyre::Separate(Stream stream, int stream_count, Material::Ptr mat)
   Material::Ptr material;
   switch (stream_count) {
     case 1:
-      material = v->VoloxSepMaterial(stream.second, mat);
+      material = v.VoloxSepMaterial(stream.second, mat);
       Record("Volox", material->quantity(), "test");
       break;
     case 2:
-      material = rd->ReductSepMaterial(stream.second, mat);
+      material = rd.ReductSepMaterial(stream.second, mat);
       break;
     case 3:
     case 4:
-      material = rf->RefineSepMaterial(stream.second, mat);
+      material = rf.RefineSepMaterial(stream.second, mat);
       break;
     case 5:
-      material = w->WinningSepMaterial(stream.second, mat);
+      material = w.WinningSepMaterial(stream.second, mat);
       break;
   }
   return material;

--- a/src/pyre.cc
+++ b/src/pyre.cc
@@ -55,16 +55,16 @@ typedef std::map<std::string, Stream> StreamSet;
 void Pyre::EnterNotify() {
   Volox vol = Volox(volox_temp, volox_time, volox_flowrate, 
           volox_volume);
-        v = &vol;
+        v = vol;
         Reduct red = Reduct(reduct_current, reduct_lithium_oxide, 
           reduct_volume, reduct_time);
-        rd = &red;
+        rd = red;
         Refine ref = Refine(refine_temp, refine_press, refine_rotation, 
           refine_batch_size, refine_time);
-        rf = &ref;
+        rf = ref;
         Winning win = Winning(winning_current, winning_time, winning_flowrate, 
           winning_volume);
-        w = &win;
+        w = win;
   cyclus::Facility::EnterNotify();
   std::map<int, double> efficiency_;
 
@@ -133,7 +133,6 @@ void Pyre::Tick() {
   for (it = streams_.begin(); it != streams_.end(); ++it) {
     Stream info = it->second;
     std::string name = it->first;
-    std::cout << "Stream number " << stream_count << std::endl;
     stagedsep[name] = Separate(name, info, stream_count, mat);
     double frac = streambufs[name].space() / stagedsep[name]->quantity();
     if (frac < maxfrac) {
@@ -146,9 +145,6 @@ void Pyre::Tick() {
   for (itf = stagedsep.begin(); itf != stagedsep.end(); ++itf) {
     std::string name = itf->first;
     Material::Ptr m = itf->second;
-    std::cout << name << std::endl;
-    std::cout << m->quantity() << std::endl;
-    std::cout << maxfrac << std::endl;
     if (m->quantity() > 0) {
       streambufs[name].Push(
           mat->ExtractComp(m->quantity() * maxfrac, m->comp()));

--- a/src/pyre.h
+++ b/src/pyre.h
@@ -117,10 +117,10 @@ class Pyre
   virtual void InitInv(cyclus::Inventories& inv);
 
  private:
-  Volox* v;
-  Reduct* rd;
-  Refine* rf;
-  Winning* w;
+  Volox v;
+  Reduct rd;
+  Refine rf;
+  Winning w;
  
   #pragma cyclus var { \
     "doc": "Ordered list of commodities on which to request feed material to " \

--- a/src/pyre.h
+++ b/src/pyre.h
@@ -82,8 +82,7 @@ class Pyre
   typedef std::pair<double, std::map<int, double> > Stream;
   typedef std::map<std::string, Stream> StreamSet;
 
-  cyclus::Material::Ptr Separate(Stream stream, int stream_count, 
-    cyclus::Material::Ptr sep);
+  cyclus::Material::Ptr Separate(Stream stream, int stream_count, cyclus::Material::Ptr feed);
 
   virtual void AcceptMatlTrades(const std::vector<std::pair<
       cyclus::Trade<cyclus::Material>, cyclus::Material::Ptr> >& responses);

--- a/src/pyre.h
+++ b/src/pyre.h
@@ -82,7 +82,8 @@ class Pyre
   typedef std::pair<double, std::map<int, double> > Stream;
   typedef std::map<std::string, Stream> StreamSet;
 
-  cyclus::Material::Ptr Separate(Stream stream, int stream_count, cyclus::Material::Ptr feed);
+  cyclus::Material::Ptr Separate(std::string name, Stream stream, 
+    int stream_count, cyclus::Material::Ptr feed);
 
   virtual void AcceptMatlTrades(const std::vector<std::pair<
       cyclus::Trade<cyclus::Material>, cyclus::Material::Ptr> >& responses);

--- a/src/pyre.h
+++ b/src/pyre.h
@@ -83,7 +83,7 @@ class Pyre
   typedef std::map<std::string, Stream> StreamSet;
 
   cyclus::Material::Ptr Separate(std::string name, Stream stream, 
-    int stream_count, cyclus::Material::Ptr feed);
+    cyclus::Material::Ptr feed);
 
   virtual void AcceptMatlTrades(const std::vector<std::pair<
       cyclus::Trade<cyclus::Material>, cyclus::Material::Ptr> >& responses);

--- a/src/pyre.h
+++ b/src/pyre.h
@@ -151,6 +151,7 @@ class Pyre
   std::string feed_recipe;
 
   #pragma cyclus var { \
+  "default": 900, \
   "doc": "The temperature of the Voloxidation process", \
   "tooltip": "Voloxidation Temperature", \
   "units": "C", \

--- a/src/pyre.h
+++ b/src/pyre.h
@@ -17,8 +17,6 @@ namespace recycle {
 /// separations efficiency for that nuclide or element.  Note that this returns
 /// an untracked material that should only be used for its composition and qty
 /// - not in any real inventories, etc.
-cyclus::Material::Ptr SepMaterial(std::map<int, double> effs,
-                                  cyclus::Material::Ptr mat);
 
 /// Pyre processes feed material into multiple waste streams according to their
 /// respective sub-process. Separation uses mass-based efficiencies.
@@ -84,8 +82,8 @@ class Pyre
   typedef std::pair<double, std::map<int, double> > Stream;
   typedef std::map<std::string, Stream> StreamSet;
 
-  cyclus::Material::Ptr Separate(Stream stream, std::string name, int stream_count, 
-    cyclus::Material::Ptr feed);
+  cyclus::Material::Ptr Separate(Stream stream, int stream_count, 
+    cyclus::Material::Ptr sep);
 
   virtual void AcceptMatlTrades(const std::vector<std::pair<
       cyclus::Trade<cyclus::Material>, cyclus::Material::Ptr> >& responses);
@@ -418,6 +416,10 @@ class Pyre
 
   /// Records an agent's latitude and longitude to the output db
   void RecordPosition();
+
+  void Record(std::string name, double val, std::string type);
+
+  void RecordStreams();
 };
 
 }  // namespace recycle

--- a/src/pyre_reduction.cc
+++ b/src/pyre_reduction.cc
@@ -34,7 +34,7 @@ Material::Ptr Reduct::ReductSepMaterial(std::map<int, double> effs,
   CompMap::iterator it;
   for (it = cm.begin(); it != cm.end(); ++it) {
     int nuc = it->first;
-    int elem = nuc;
+    int elem = (nuc / 10000000) * 10000000;
     double eff = 0;
     if (effs.count(nuc) > 0) {
       eff = effs[nuc];

--- a/src/pyre_reduction.cc
+++ b/src/pyre_reduction.cc
@@ -30,6 +30,7 @@ Material::Ptr Reduct::ReductSepMaterial(std::map<int, double> effs,
   cyclus::compmath::Normalize(&cm, mat->quantity());
   double tot_qty = 0;
   CompMap sepcomp;
+  double sepeff = Efficiency(current, lithium_oxide);
 
   CompMap::iterator it;
   for (it = cm.begin(); it != cm.end(); ++it) {
@@ -45,7 +46,7 @@ Material::Ptr Reduct::ReductSepMaterial(std::map<int, double> effs,
     }
 
     double qty = it->second;
-    double sepqty = qty * eff * Reduct::Efficiency(current, lithium_oxide);
+    double sepqty = qty * eff * sepeff;
     sepcomp[nuc] = sepqty;
     tot_qty += sepqty;
   }

--- a/src/pyre_reduction.cc
+++ b/src/pyre_reduction.cc
@@ -47,8 +47,6 @@ Material::Ptr Reduct::ReductSepMaterial(std::map<int, double> effs,
 
     double qty = it->second;
     double sepqty = qty * eff * sepeff;
-    std::cout << nuc << std::endl;
-    std::cout << "Nuc Id qty: " << sepqty << std::endl;
     sepcomp[nuc] = sepqty;
     tot_qty += sepqty;
   }
@@ -61,8 +59,6 @@ double Reduct::Efficiency(double current, double lithium_oxide) {
   double coulombic_eff = -0.00685*pow(current,4) + 0.20413*pow(current,3) 
                          - 2.273*pow(current,2) + 11.2046*current - 19.7493;
   double catalyst_eff = 0.075 * lithium_oxide + 0.775;
-  std::cout << "Coulombic = " << coulombic_eff << std::endl;
-  std::cout << "Lithim = " << catalyst_eff << std::endl;
   double reduct_eff = coulombic_eff * catalyst_eff;
   return reduct_eff;
 }

--- a/src/pyre_reduction.cc
+++ b/src/pyre_reduction.cc
@@ -47,6 +47,8 @@ Material::Ptr Reduct::ReductSepMaterial(std::map<int, double> effs,
 
     double qty = it->second;
     double sepqty = qty * eff * sepeff;
+    std::cout << nuc << std::endl;
+    std::cout << "Nuc Id qty: " << sepqty << std::endl;
     sepcomp[nuc] = sepqty;
     tot_qty += sepqty;
   }
@@ -59,6 +61,8 @@ double Reduct::Efficiency(double current, double lithium_oxide) {
   double coulombic_eff = -0.00685*pow(current,4) + 0.20413*pow(current,3) 
                          - 2.273*pow(current,2) + 11.2046*current - 19.7493;
   double catalyst_eff = 0.075 * lithium_oxide + 0.775;
+  std::cout << "Coulombic = " << coulombic_eff << std::endl;
+  std::cout << "Lithim = " << catalyst_eff << std::endl;
   double reduct_eff = coulombic_eff * catalyst_eff;
   return reduct_eff;
 }

--- a/src/pyre_reduction.h
+++ b/src/pyre_reduction.h
@@ -8,11 +8,6 @@ namespace recycle {
 
 class Reduct {
 
-double current;
-double lithium_oxide;
-double volume;
-double reprocess_time;
-
 public:
 
 Reduct();
@@ -24,6 +19,13 @@ Reduct(double reduct_current,double reduct_li2o,double reduct_volume,double redu
 /// @return composition composition of the separated material sent to refining
 cyclus::Material::Ptr ReductSepMaterial(std::map<int, double> effs,
 	cyclus::Material::Ptr mat);
+
+private:
+
+double current;
+double lithium_oxide;
+double volume;
+double reprocess_time;
 
 double Efficiency(double current, double lithium_oxide);
 

--- a/src/pyre_refining.cc
+++ b/src/pyre_refining.cc
@@ -70,7 +70,6 @@ double Refine::Efficiency(double temp, double pressure, double rotation) {
     }
   }
   double refine_eff = thermal * pres_eff * agitation;
-  std::cout << "Refine Eff = " << pres_eff << std::endl;
   return refine_eff;
 }
 

--- a/src/pyre_refining.cc
+++ b/src/pyre_refining.cc
@@ -35,7 +35,7 @@ Material::Ptr Refine::RefineSepMaterial(std::map<int, double> effs, Material::Pt
   CompMap::iterator it;
   for (it = cm.begin(); it != cm.end(); ++it) {
     int nuc = it->first;
-    int elem = nuc;
+    int elem = (nuc / 10000000) * 10000000;
     double eff = 0;
     if (effs.count(nuc) > 0) {
       eff = effs[nuc];

--- a/src/pyre_refining.cc
+++ b/src/pyre_refining.cc
@@ -17,7 +17,7 @@ Refine::Refine() {}
 Refine::Refine(double refine_temp = 900, double refine_press = 760, 
                double refine_rotation = 0, double refine_batch_size = 20,
                double refine_time = 1) {
-  temperature = refine_temp;
+  temp = refine_temp;
   pressure = refine_press;
   rotation = refine_rotation;
   batch_size = refine_batch_size;
@@ -31,7 +31,7 @@ Material::Ptr Refine::RefineSepMaterial(std::map<int, double> effs, Material::Pt
   cyclus::compmath::Normalize(&cm, mat->quantity());
   double tot_qty = 0;
   CompMap sepcomp;
-  double sepeff = Efficiency(temperature, pressure, rotation);
+  double sepeff = Efficiency(temp, pressure, rotation);
 
   CompMap::iterator it;
   for (it = cm.begin(); it != cm.end(); ++it) {
@@ -56,21 +56,21 @@ Material::Ptr Refine::RefineSepMaterial(std::map<int, double> effs, Material::Pt
   return Material::CreateUntracked(tot_qty, c);
 }
 
-double Refine::Efficiency(double temperature, double pressure, double rotation) {
+double Refine::Efficiency(double temp, double pressure, double rotation) {
   double agitation;
-  double thermal = (8.8333E-7*pow(temperature,3) - 0.00255*(temperature,2)
-                   +2.4572*temperature-691.1) / 100;
-  double pres_eff = -0.0055128 * pressure + 100.5;
+  double thermal = 4.7369E-9*pow(temp,3) - 1.08337E-5*pow(temp,2)
+    +0.008069*temp-0.9726;
+  double pres_eff = -4.6667*pow(pressure,-5) + 1.002;
   if (rotation <= 1) {
     agitation = 0.032*rotation + 0.72;
   } else {
     agitation = 0.0338396*log(rotation)+0.836671495;
     if (agitation > 1) {
-      std::cout << "Rotation = " << rotation << std::endl;
       throw ValueError("Rotation efficiency cannot exceed 1");
     }
   }
   double refine_eff = thermal * pres_eff * agitation;
+  std::cout << "Refine Eff = " << pres_eff << std::endl;
   return refine_eff;
 }
 

--- a/src/pyre_refining.cc
+++ b/src/pyre_refining.cc
@@ -31,6 +31,7 @@ Material::Ptr Refine::RefineSepMaterial(std::map<int, double> effs, Material::Pt
   cyclus::compmath::Normalize(&cm, mat->quantity());
   double tot_qty = 0;
   CompMap sepcomp;
+  double sepeff = Efficiency(temperature, pressure, rotation);
 
   CompMap::iterator it;
   for (it = cm.begin(); it != cm.end(); ++it) {
@@ -46,7 +47,7 @@ Material::Ptr Refine::RefineSepMaterial(std::map<int, double> effs, Material::Pt
     }
 
     double qty = it->second;
-    double sepqty = qty * eff * Refine::Efficiency(temperature, pressure, rotation);
+    double sepqty = qty * eff * sepeff;
     sepcomp[nuc] = sepqty;
     tot_qty += sepqty;
   }
@@ -63,8 +64,9 @@ double Refine::Efficiency(double temperature, double pressure, double rotation) 
   if (rotation <= 1) {
     agitation = 0.032*rotation + 0.72;
   } else {
-    agitation = 0.0369924675*log(rotation)+0.829777331;
+    agitation = 0.0338396*log(rotation)+0.836671495;
     if (agitation > 1) {
+      std::cout << "Rotation = " << rotation << std::endl;
       throw ValueError("Rotation efficiency cannot exceed 1");
     }
   }

--- a/src/pyre_refining.h
+++ b/src/pyre_refining.h
@@ -8,12 +8,6 @@ namespace recycle {
 
 class Refine{
 
-double temperature;
-double pressure;
-double rotation;
-double batch_size;
-double reprocess_time;
-
 public:
 
 Refine();
@@ -25,6 +19,14 @@ Refine(double refine_temp, double refine_press, double refine_rotation, double r
 /// @return composition composition of the separated material sent to electrowinning
 cyclus::Material::Ptr RefineSepMaterial(std::map<int, double> effs,
 	cyclus::Material::Ptr mat);
+
+private:
+
+double temperature;
+double pressure;
+double rotation;
+double batch_size;
+double reprocess_time;
 
 double Efficiency(double temperature, double pressure, double rotation);
 

--- a/src/pyre_refining.h
+++ b/src/pyre_refining.h
@@ -22,13 +22,13 @@ cyclus::Material::Ptr RefineSepMaterial(std::map<int, double> effs,
 
 private:
 
-double temperature;
+double temp;
 double pressure;
 double rotation;
 double batch_size;
 double reprocess_time;
 
-double Efficiency(double temperature, double pressure, double rotation);
+double Efficiency(double temp, double pressure, double rotation);
 
 double Throughput(double batch_size, double reprocess_time);
 };

--- a/src/pyre_volox.cc
+++ b/src/pyre_volox.cc
@@ -18,13 +18,12 @@ Volox::Volox(double volox_temp,
              double volox_time, 
              double volox_flowrate, 
              double volox_volume
-        ) : 
-        temp( volox_temp ),
-        reprocess_time( volox_time ),
-        flowrate( volox_flowrate ),
-        volume( volox_volume ) 
+        ) 
         {
-          std::cout << "Volox Temp = " << temp << std::endl;
+          set_temp( volox_temp );
+          set_time( volox_time );
+          set_flowrate( volox_flowrate );
+          set_volume( volox_volume ); 
         }
 
 // This returns an untracked material that should just be used for
@@ -35,6 +34,7 @@ Material::Ptr Volox::VoloxSepMaterial(std::map<int, double> effs, Material::Ptr 
   cyclus::compmath::Normalize(&cm, mat->quantity());
   double tot_qty = 0;
   CompMap sepcomp;
+  double sepeff = Efficiency(temp, reprocess_time, flowrate);
 
   CompMap::iterator it;
   for (it = cm.begin(); it != cm.end(); ++it) {
@@ -50,9 +50,7 @@ Material::Ptr Volox::VoloxSepMaterial(std::map<int, double> effs, Material::Ptr 
       continue;
     }
     double qty = it->second;
-    std::cout << "hi" << std::endl;
-    double sepqty = qty * eff * Efficiency(temp, reprocess_time, flowrate);
-    std::cout << "hi2" << std::endl;
+    double sepqty = qty * eff * sepeff;
     sepcomp[nuc] = sepqty;
     tot_qty += sepqty;
   }
@@ -66,9 +64,9 @@ double Volox::Efficiency(double temp, double reprocess_time, double flowrate) {
   double temporal = 0.2903 * log(reprocess_time*3600) - 1.696;
   double rate = 0.12435 * log(flowrate) + 0.7985;
   double volox_eff = thermal * temporal * rate;
-  std::cout << "Thermal = " << temp << std::endl;
-  std::cout << "Temporal = " << reprocess_time << std::endl;
-  std::cout << "rate = " << flowrate << std::endl;
+  std::cout << "Thermal = " << thermal << std::endl;
+  std::cout << "Temporal = " << temporal << std::endl;
+  std::cout << "rate = " << rate << std::endl;
   return volox_eff;
 }
 
@@ -76,5 +74,21 @@ double Volox::Throughput(double flowrate, double reprocess_time, double volume) 
   // placeholder calculation
   double volox_through = volume / flowrate*reprocess_time;
   return volox_through;
+}
+
+void Volox::set_temp(double input) {
+  temp = input;
+}
+
+void Volox::set_time(double input) {
+  reprocess_time = input;
+}
+
+void Volox::set_flowrate(double input) {
+  flowrate = input;
+}
+
+void Volox::set_volume(double input) {
+  volume = input;
 }
 }

--- a/src/pyre_volox.cc
+++ b/src/pyre_volox.cc
@@ -14,17 +14,23 @@ namespace recycle {
 
 Volox::Volox() {}
 
-Volox::Volox(double volox_temp = 900, double volox_time = 1, 
-             double volox_flowrate = 3, double volox_volume = 1){
-  temp = volox_temp;
-  reprocess_time = volox_time;
-  flowrate = volox_flowrate;
-  volume = volox_volume;
-}
+Volox::Volox(double volox_temp, 
+             double volox_time, 
+             double volox_flowrate, 
+             double volox_volume
+        ) : 
+        temp( volox_temp ),
+        reprocess_time( volox_time ),
+        flowrate( volox_flowrate ),
+        volume( volox_volume ) 
+        {
+          std::cout << "Volox Temp = " << temp << std::endl;
+        }
 
 // This returns an untracked material that should just be used for
 // its composition and qty - not in any real inventories, etc.
 Material::Ptr Volox::VoloxSepMaterial(std::map<int, double> effs, Material::Ptr mat) {
+  std::cout << "Temp = " << temp << std::endl;
   CompMap cm = mat->comp()->mass();
   cyclus::compmath::Normalize(&cm, mat->quantity());
   double tot_qty = 0;
@@ -33,8 +39,9 @@ Material::Ptr Volox::VoloxSepMaterial(std::map<int, double> effs, Material::Ptr 
   CompMap::iterator it;
   for (it = cm.begin(); it != cm.end(); ++it) {
     int nuc = it->first;
-    int elem = nuc;
+    int elem = (nuc / 10000000) * 10000000;
     double eff = 0;
+    std::cout << nuc << std::endl;
     if (effs.count(nuc) > 0) {
       eff = effs[nuc];
     } else if (effs.count(elem) > 0) {
@@ -42,22 +49,26 @@ Material::Ptr Volox::VoloxSepMaterial(std::map<int, double> effs, Material::Ptr 
     } else {
       continue;
     }
-
     double qty = it->second;
-    double sepqty = qty * eff * Volox::Efficiency(temp, reprocess_time, flowrate);
+    std::cout << "hi" << std::endl;
+    double sepqty = qty * eff * Efficiency(temp, reprocess_time, flowrate);
+    std::cout << "hi2" << std::endl;
     sepcomp[nuc] = sepqty;
     tot_qty += sepqty;
   }
-
+  std::cout << "CreateFromMass" << std::endl;
   Composition::Ptr c = Composition::CreateFromMass(sepcomp);
   return Material::CreateUntracked(tot_qty, c);
 }
 
 double Volox::Efficiency(double temp, double reprocess_time, double flowrate) {
-  double thermal = (8.8333E-7*pow(temp,3) - 0.001755*(temp,2)+1.166*temp-159.6) / 100;
+  double thermal = 4.7369E-9*pow(temp,3) - 1.08337E-5*pow(temp,2)+0.008069*temp-0.9726;
   double temporal = 0.2903 * log(reprocess_time*3600) - 1.696;
   double rate = 0.12435 * log(flowrate) + 0.7985;
   double volox_eff = thermal * temporal * rate;
+  std::cout << "Thermal = " << temp << std::endl;
+  std::cout << "Temporal = " << reprocess_time << std::endl;
+  std::cout << "rate = " << flowrate << std::endl;
   return volox_eff;
 }
 

--- a/src/pyre_volox.cc
+++ b/src/pyre_volox.cc
@@ -29,7 +29,6 @@ Volox::Volox(double volox_temp,
 // This returns an untracked material that should just be used for
 // its composition and qty - not in any real inventories, etc.
 Material::Ptr Volox::VoloxSepMaterial(std::map<int, double> effs, Material::Ptr mat) {
-  std::cout << "Temp = " << temp << std::endl;
   CompMap cm = mat->comp()->mass();
   cyclus::compmath::Normalize(&cm, mat->quantity());
   double tot_qty = 0;
@@ -41,7 +40,6 @@ Material::Ptr Volox::VoloxSepMaterial(std::map<int, double> effs, Material::Ptr 
     int nuc = it->first;
     int elem = (nuc / 10000000) * 10000000;
     double eff = 0;
-    std::cout << nuc << std::endl;
     if (effs.count(nuc) > 0) {
       eff = effs[nuc];
     } else if (effs.count(elem) > 0) {
@@ -54,7 +52,6 @@ Material::Ptr Volox::VoloxSepMaterial(std::map<int, double> effs, Material::Ptr 
     sepcomp[nuc] = sepqty;
     tot_qty += sepqty;
   }
-  std::cout << "CreateFromMass" << std::endl;
   Composition::Ptr c = Composition::CreateFromMass(sepcomp);
   return Material::CreateUntracked(tot_qty, c);
 }
@@ -64,9 +61,6 @@ double Volox::Efficiency(double temp, double reprocess_time, double flowrate) {
   double temporal = 0.2903 * log(reprocess_time*3600) - 1.696;
   double rate = 0.12435 * log(flowrate) + 0.7985;
   double volox_eff = thermal * temporal * rate;
-  std::cout << "Thermal = " << thermal << std::endl;
-  std::cout << "Temporal = " << temporal << std::endl;
-  std::cout << "rate = " << rate << std::endl;
   return volox_eff;
 }
 

--- a/src/pyre_volox.cc
+++ b/src/pyre_volox.cc
@@ -44,7 +44,7 @@ Material::Ptr Volox::VoloxSepMaterial(std::map<int, double> effs, Material::Ptr 
     }
 
     double qty = it->second;
-    double sepqty = qty * eff * Efficiency(temp, reprocess_time, flowrate);
+    double sepqty = qty * eff * Volox::Efficiency(temp, reprocess_time, flowrate);
     sepcomp[nuc] = sepqty;
     tot_qty += sepqty;
   }

--- a/src/pyre_volox.cc
+++ b/src/pyre_volox.cc
@@ -44,7 +44,7 @@ Material::Ptr Volox::VoloxSepMaterial(std::map<int, double> effs, Material::Ptr 
     }
 
     double qty = it->second;
-    double sepqty = qty * eff * Volox::Efficiency(temp, reprocess_time, flowrate);
+    double sepqty = qty * eff * Efficiency(temp, reprocess_time, flowrate);
     sepcomp[nuc] = sepqty;
     tot_qty += sepqty;
   }

--- a/src/pyre_volox.h
+++ b/src/pyre_volox.h
@@ -9,11 +9,6 @@ namespace recycle {
 
 class Volox {
 
-double temp;
-double reprocess_time;
-double flowrate;
-double volume;
-
 public:
 
 Volox();
@@ -25,6 +20,13 @@ Volox(double volox_temp, double volox_time, double volox_flowrate, double volox_
 /// @return composition composition of the resulting product and waste
 cyclus::Material::Ptr VoloxSepMaterial(std::map<int, double> effs,
 	cyclus::Material::Ptr mat);
+
+private:
+
+double temp;
+double reprocess_time;
+double flowrate;
+double volume;
 
 /// @param temp temperature of the volox process
 /// @param time time spent in the process

--- a/src/pyre_volox.h
+++ b/src/pyre_volox.h
@@ -36,6 +36,14 @@ double Efficiency(double temp, double reprocess_time, double flowrate);
 
 /// @return throughput material throughput of voloxidation
 double Throughput(double flowrate, double reprocess_time, double volume);
+
+void set_temp(double input);
+
+void set_time(double input);
+
+void set_flowrate(double input);
+
+void set_volume(double input);
 };
 }
 #endif // RECYCLE_SRC_PYRE_VOLOX_H_

--- a/src/pyre_winning.cc
+++ b/src/pyre_winning.cc
@@ -32,7 +32,7 @@ Material::Ptr Winning::WinningSepMaterial(std::map<int, double> effs, Material::
   CompMap::iterator it;
   for (it = cm.begin(); it != cm.end(); ++it) {
     int nuc = it->first;
-    int elem = nuc;
+    int elem = (nuc / 10000000) * 10000000;
     double eff = 0;
     if (effs.count(nuc) > 0) {
       eff = effs[nuc];

--- a/src/pyre_winning.cc
+++ b/src/pyre_winning.cc
@@ -13,8 +13,8 @@ namespace recycle {
 
 Winning::Winning() {}
 
-Winning::Winning(double winning_current, double winning_time, 
-                 double winning_flowrate, double winning_volume) {
+Winning::Winning(double winning_current = 8, double winning_time = 1, 
+                 double winning_flowrate = 3, double winning_volume = 1) {
   current = winning_current;
   reprocess_time = winning_time;
   flowrate = winning_flowrate;

--- a/src/pyre_winning.cc
+++ b/src/pyre_winning.cc
@@ -13,8 +13,8 @@ namespace recycle {
 
 Winning::Winning() {}
 
-Winning::Winning(double winning_current = 4, double winning_time = 1, 
-                 double winning_flowrate = 3, double winning_volume = 1) {
+Winning::Winning(double winning_current, double winning_time, 
+                 double winning_flowrate, double winning_volume) {
   current = winning_current;
   reprocess_time = winning_time;
   flowrate = winning_flowrate;
@@ -28,6 +28,7 @@ Material::Ptr Winning::WinningSepMaterial(std::map<int, double> effs, Material::
   cyclus::compmath::Normalize(&cm, mat->quantity());
   double tot_qty = 0;
   CompMap sepcomp;
+  double sepeff = Efficiency(current,reprocess_time,flowrate);
 
   CompMap::iterator it;
   for (it = cm.begin(); it != cm.end(); ++it) {
@@ -43,12 +44,14 @@ Material::Ptr Winning::WinningSepMaterial(std::map<int, double> effs, Material::
     }
 
     double qty = it->second;
-    double sepqty = qty * eff * Winning::Efficiency(current,reprocess_time,flowrate);
+    double sepqty = qty * eff * sepeff;
+    std::cout << "Nuc Id qty: " << sepqty << std::endl;
     sepcomp[nuc] = sepqty;
     tot_qty += sepqty;
   }
 
   Composition::Ptr c = Composition::CreateFromMass(sepcomp);
+  std::cout << "blah" << std::endl;
   return Material::CreateUntracked(tot_qty, c);
 }
 
@@ -57,6 +60,9 @@ double Winning::Efficiency(double current, double reprocess_time, double flowrat
                          - 2.273*pow(current,2) + 11.2046*current - 19.7493;
   double temporal = 0.2903 * log(reprocess_time*3600) - 1.696;
   double rate = 0.12435 * log(flowrate) + 0.7985;
+  std::cout << "Thermal = " << coulombic_eff << std::endl;
+  std::cout << "Temporal = " << temporal << std::endl;
+  std::cout << "rate = " << rate << std::endl;
   double winning_eff = coulombic_eff * temporal * rate;
   return winning_eff;
 }

--- a/src/pyre_winning.cc
+++ b/src/pyre_winning.cc
@@ -45,13 +45,11 @@ Material::Ptr Winning::WinningSepMaterial(std::map<int, double> effs, Material::
 
     double qty = it->second;
     double sepqty = qty * eff * sepeff;
-    std::cout << "Nuc Id qty: " << sepqty << std::endl;
     sepcomp[nuc] = sepqty;
     tot_qty += sepqty;
   }
 
   Composition::Ptr c = Composition::CreateFromMass(sepcomp);
-  std::cout << "blah" << std::endl;
   return Material::CreateUntracked(tot_qty, c);
 }
 
@@ -60,9 +58,6 @@ double Winning::Efficiency(double current, double reprocess_time, double flowrat
                          - 2.273*pow(current,2) + 11.2046*current - 19.7493;
   double temporal = 0.2903 * log(reprocess_time*3600) - 1.696;
   double rate = 0.12435 * log(flowrate) + 0.7985;
-  std::cout << "Thermal = " << coulombic_eff << std::endl;
-  std::cout << "Temporal = " << temporal << std::endl;
-  std::cout << "rate = " << rate << std::endl;
   double winning_eff = coulombic_eff * temporal * rate;
   return winning_eff;
 }

--- a/src/pyre_winning.h
+++ b/src/pyre_winning.h
@@ -9,11 +9,6 @@ namespace recycle {
 
 class Winning {
 
-double current;
-double reprocess_time;
-double flowrate;
-double volume;
-
 public:
 
 Winning();
@@ -24,6 +19,13 @@ Winning(double winning_current, double winning_time, double winning_flowrate, do
 /// @return composition composition of the separated material sent to fuel fabrication
 cyclus::Material::Ptr WinningSepMaterial(std::map<int, double> effs,
 	cyclus::Material::Ptr mat);
+
+private:
+
+double current;
+double reprocess_time;
+double flowrate;
+double volume;
 
 double Efficiency(double current, double reprocess_time, double flowrate);
 


### PR DESCRIPTION
Adds Record function for stream outputs - in doing so found a number of bugs in the code that were not found at first glance. Therefore this PR is much larger than originally intended. This closes #7 .

- Removes the "stream_counts" variable. Instead, stream names are used such that stream names must contain the name of the sub-process they are sent to (e.g. volox_waste or refine_U_prod).

- In the SepMaterial function `int elem = nuc` would result in the function failing. However, `int elem = (nuc / 1000000) * 1000000` processed the CompMap correctly. Not sure why this is the case for the separations archetype.

- Another problem I ran into was the Pyre constructor did not have the input values when constructing sub-process objects. I've moved them into EnterNotify for the time being, at which point the inputs have been read and correctly pass into the constructors.

- Sub-process efficiencies functions were moved such that they are only called once per instance.