### PR TITLE
CMake Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,9 +255,11 @@ IF(NOT CYCLUS_DOC_ONLY)
         set(LIBS ${LIBS} ${PYTHON_LIBRARIES})
     ENDIF(PYTHON_LIBRARIES)
 
+    # Source Directory
+    set(RECYCLE_INCLUDE_DIRS ${RECYCLE_INCLUDE_DIRS} src)
+
     # include all the directories we just found
     INCLUDE_DIRECTORIES(${RECYCLE_INCLUDE_DIRS})
-    INCLUDE_DIRECTORIES(src)
 
     # ------------------------- Add the Agents -----------------------------------
     ADD_SUBDIRECTORY(src)


### PR DESCRIPTION
Adds the source directory to the RECYCLE_INCLUDE_DIRS for cleaner INCLUDE_DIRECTORIES.