### PR TITLE
Updating default value convention and Documentation

### DIFF
--- a/src/toolkit/diverter.cc
+++ b/src/toolkit/diverter.cc
@@ -7,7 +7,7 @@ namespace recycle {
 Diverter::Diverter() {}
 
 Diverter::Diverter(std::pair<std::string,std::string> location, 
-    int frequency = 1E299, double quantity = 0.01, int divert_number = 1, std::string type_ = "operator") {
+    int frequency, double quantity, int divert_number, std::string type_) {
     locate(location);
     freq(frequency);
     siphon(quantity);

--- a/src/toolkit/diverter.h
+++ b/src/toolkit/diverter.h
@@ -17,14 +17,15 @@ class Diverter {
   /// @param location where diversion will take place given by sub-process and parameter
   std::pair<std::string, std::string> location;
   /// @param frequency how many time steps take place between diversions 1e299 means no diversion
-  int frequency;
+  int frequency = 1E299;
   /// @param divert_number how many times diversion should take place within a scenario
-  int divert_number;
+  int divert_number = 1;
   /// @param divert_times keeps track how many times diversion has taken place
   int divert_times;
   /// @param quantity how much material will be siphoned off at diversion
-  double quantity;
-  std::string type;
+  double quantity = 0.01;
+  /// @param type The type of diversion occuring: Operator or Nefarious
+  std::string type = "operator";
 
   Diverter();
 

--- a/src/toolkit/pyroprocessing/pyre_reduction.cc
+++ b/src/toolkit/pyroprocessing/pyre_reduction.cc
@@ -8,16 +8,16 @@ namespace pyro {
 
 Reduct::Reduct() {
   SetCoeff();
-  current(0);
-  lithium(0);
-  volume(0);
-  Rtime(0);
+  current(5);
+  lithium(2);
+  volume(10);
+  Rtime(1);
 }
 
-Reduct::Reduct(double new_current = 5, 
-               double new_lithium = 2, 
-               double new_volume = 10, 
-               double new_Rtime = 1
+Reduct::Reduct(double new_current, 
+               double new_lithium, 
+               double new_volume, 
+               double new_Rtime
             ) 
             {
               SetCoeff();
@@ -54,4 +54,3 @@ double Reduct::Throughput() {
   return volume() / Rtime();
 };
 } // namespace pyro
-

--- a/src/toolkit/pyroprocessing/pyre_reduction.h
+++ b/src/toolkit/pyroprocessing/pyre_reduction.h
@@ -22,6 +22,15 @@ class Reduct : public pyro::Process {
 	double reduct_volume, double reduct_time);
 
  private:
+  /// The coefficients are derived from the following:
+  /// [1]E.-Y. Choi and S. M. Jeong, “Electrochemical processing of spent nuclear fuels: 
+  ///   An overview of oxide reduction in pyroprocessing technology,” Progress in Natural Science: 
+  ///   Materials International, vol. 25, no. 6, pp. 572–582, Dec. 2015.
+  /// [2]T.-J. Kim, G.-Y. Kim, D. Yoon, D.-H. Ahn, and S. Paek, “Development of an anode structure 
+  ///   consisting of graphite tubes and a SiC shroud for the electrowinning process in 
+  ///   molten salt,” Journal of Radioanalytical and Nuclear Chemistry, vol. 295, no. 3, 
+  ///   pp. 1855–1859, Mar. 2013.
+
 
   /// Coulombic efficiency coefficients
   std::vector<double> coul;

--- a/src/toolkit/pyroprocessing/pyre_reduction.h
+++ b/src/toolkit/pyroprocessing/pyre_reduction.h
@@ -44,6 +44,6 @@ class Reduct : public pyro::Process {
 
   double Throughput();
 };
-} // namespace recycle
+} // namespace pyro
 #endif // RECYCLE_SRC_PYRE_REDUCTION_H_
 

--- a/src/toolkit/pyroprocessing/pyre_reduction.h
+++ b/src/toolkit/pyroprocessing/pyre_reduction.h
@@ -22,14 +22,14 @@ class Reduct : public pyro::Process {
 	double reduct_volume, double reduct_time);
 
  private:
-  /// The coefficients are derived from the following:
-  /// [1]E.-Y. Choi and S. M. Jeong, “Electrochemical processing of spent nuclear fuels: 
-  ///   An overview of oxide reduction in pyroprocessing technology,” Progress in Natural Science: 
-  ///   Materials International, vol. 25, no. 6, pp. 572–582, Dec. 2015.
-  /// [2]T.-J. Kim, G.-Y. Kim, D. Yoon, D.-H. Ahn, and S. Paek, “Development of an anode structure 
-  ///   consisting of graphite tubes and a SiC shroud for the electrowinning process in 
-  ///   molten salt,” Journal of Radioanalytical and Nuclear Chemistry, vol. 295, no. 3, 
-  ///   pp. 1855–1859, Mar. 2013.
+  // The coefficients are derived from the following:
+  // [1]E.-Y. Choi and S. M. Jeong, “Electrochemical processing of spent nuclear fuels: 
+  //   An overview of oxide reduction in pyroprocessing technology,” Progress in Natural Science: 
+  //   Materials International, vol. 25, no. 6, pp. 572–582, Dec. 2015.
+  // [2]T.-J. Kim, G.-Y. Kim, D. Yoon, D.-H. Ahn, and S. Paek, “Development of an anode structure 
+  //   consisting of graphite tubes and a SiC shroud for the electrowinning process in 
+  //   molten salt,” Journal of Radioanalytical and Nuclear Chemistry, vol. 295, no. 3, 
+  //   pp. 1855–1859, Mar. 2013.
 
 
   /// Coulombic efficiency coefficients

--- a/src/toolkit/pyroprocessing/pyre_reduction.h
+++ b/src/toolkit/pyroprocessing/pyre_reduction.h
@@ -25,7 +25,7 @@ class Reduct : public pyro::Process {
   /// The coefficients are derived from the following:
   /// 1 E.-Y. Choi and S. M. Jeong, "Electrochemical processing of spent nuclear fuels: 
   ///   An overview of oxide reduction in pyroprocessing technology," Progress in Natural Science: 
-  ///   Materials International, vol. 25, no. 6, pp. 572–582, Dec. 2015.
+  ///   Materials International, vol. 25, no. 6, pp. 572-582, Dec. 2015.
   /// 2 T.-J. Kim, G.-Y. Kim, D. Yoon, D.-H. Ahn, and S. Paek, "Development of an anode structure 
   ///   consisting of graphite tubes and a SiC shroud for the electrowinning process in 
   ///   molten salt," Journal of Radioanalytical and Nuclear Chemistry, vol. 295, no. 3, 

--- a/src/toolkit/pyroprocessing/pyre_reduction.h
+++ b/src/toolkit/pyroprocessing/pyre_reduction.h
@@ -22,6 +22,7 @@ class Reduct : public pyro::Process {
 	double reduct_volume, double reduct_time);
 
  private:
+
   // The coefficients are derived from the following:
   // [1]E.-Y. Choi and S. M. Jeong, “Electrochemical processing of spent nuclear fuels: 
   //   An overview of oxide reduction in pyroprocessing technology,” Progress in Natural Science: 
@@ -30,7 +31,6 @@ class Reduct : public pyro::Process {
   //   consisting of graphite tubes and a SiC shroud for the electrowinning process in 
   //   molten salt,” Journal of Radioanalytical and Nuclear Chemistry, vol. 295, no. 3, 
   //   pp. 1855–1859, Mar. 2013.
-
 
   /// Coulombic efficiency coefficients
   std::vector<double> coul;

--- a/src/toolkit/pyroprocessing/pyre_reduction.h
+++ b/src/toolkit/pyroprocessing/pyre_reduction.h
@@ -29,7 +29,7 @@ class Reduct : public pyro::Process {
   /// 2 T.-J. Kim, G.-Y. Kim, D. Yoon, D.-H. Ahn, and S. Paek, "Development of an anode structure 
   ///   consisting of graphite tubes and a SiC shroud for the electrowinning process in 
   ///   molten salt," Journal of Radioanalytical and Nuclear Chemistry, vol. 295, no. 3, 
-  ///   pp. 1855–1859, Mar. 2013.
+  ///   pp. 1855-1859, Mar. 2013.
 
 
   /// Coulombic efficiency coefficients

--- a/src/toolkit/pyroprocessing/pyre_reduction.h
+++ b/src/toolkit/pyroprocessing/pyre_reduction.h
@@ -22,15 +22,15 @@ class Reduct : public pyro::Process {
 	double reduct_volume, double reduct_time);
 
  private:
-
   // The coefficients are derived from the following:
-  // [1]E.-Y. Choi and S. M. Jeong, “Electrochemical processing of spent nuclear fuels: 
+  // 1 E.-Y. Choi and S. M. Jeong, “Electrochemical processing of spent nuclear fuels: 
   //   An overview of oxide reduction in pyroprocessing technology,” Progress in Natural Science: 
   //   Materials International, vol. 25, no. 6, pp. 572–582, Dec. 2015.
-  // [2]T.-J. Kim, G.-Y. Kim, D. Yoon, D.-H. Ahn, and S. Paek, “Development of an anode structure 
+  // 2 T.-J. Kim, G.-Y. Kim, D. Yoon, D.-H. Ahn, and S. Paek, “Development of an anode structure 
   //   consisting of graphite tubes and a SiC shroud for the electrowinning process in 
   //   molten salt,” Journal of Radioanalytical and Nuclear Chemistry, vol. 295, no. 3, 
   //   pp. 1855–1859, Mar. 2013.
+
 
   /// Coulombic efficiency coefficients
   std::vector<double> coul;

--- a/src/toolkit/pyroprocessing/pyre_reduction.h
+++ b/src/toolkit/pyroprocessing/pyre_reduction.h
@@ -22,14 +22,14 @@ class Reduct : public pyro::Process {
 	double reduct_volume, double reduct_time);
 
  private:
-  // The coefficients are derived from the following:
-  // 1 E.-Y. Choi and S. M. Jeong, “Electrochemical processing of spent nuclear fuels: 
-  //   An overview of oxide reduction in pyroprocessing technology,” Progress in Natural Science: 
-  //   Materials International, vol. 25, no. 6, pp. 572–582, Dec. 2015.
-  // 2 T.-J. Kim, G.-Y. Kim, D. Yoon, D.-H. Ahn, and S. Paek, “Development of an anode structure 
-  //   consisting of graphite tubes and a SiC shroud for the electrowinning process in 
-  //   molten salt,” Journal of Radioanalytical and Nuclear Chemistry, vol. 295, no. 3, 
-  //   pp. 1855–1859, Mar. 2013.
+  /// The coefficients are derived from the following:
+  /// 1 E.-Y. Choi and S. M. Jeong, "Electrochemical processing of spent nuclear fuels: 
+  ///   An overview of oxide reduction in pyroprocessing technology," Progress in Natural Science: 
+  ///   Materials International, vol. 25, no. 6, pp. 572–582, Dec. 2015.
+  /// 2 T.-J. Kim, G.-Y. Kim, D. Yoon, D.-H. Ahn, and S. Paek, "Development of an anode structure 
+  ///   consisting of graphite tubes and a SiC shroud for the electrowinning process in 
+  ///   molten salt," Journal of Radioanalytical and Nuclear Chemistry, vol. 295, no. 3, 
+  ///   pp. 1855–1859, Mar. 2013.
 
 
   /// Coulombic efficiency coefficients

--- a/src/toolkit/pyroprocessing/pyre_refining.cc
+++ b/src/toolkit/pyroprocessing/pyre_refining.cc
@@ -13,18 +13,18 @@ using boost::math::tools::bisect;
 namespace pyro {
 
 Refine::Refine() {
-  temp(0);
-  pressure(0);
+  temp(900);
+  pressure(760);
   rotation(0);
-  b_size(0);
-  Rtime(0);
+  b_size(20);
+  Rtime(1);
 }
 
-Refine::Refine(double new_temp = 900, 
-               double new_press = 760, 
-               double new_rotation = 0, 
-               double new_batch_size = 20,
-               double new_rtime = 1
+Refine::Refine(double new_temp, 
+               double new_press, 
+               double new_rotation, 
+               double new_batch_size,
+               double new_rtime
             ) 
             {
   SetCoeff();

--- a/src/toolkit/pyroprocessing/pyre_refining.cc
+++ b/src/toolkit/pyroprocessing/pyre_refining.cc
@@ -36,23 +36,23 @@ Refine::Refine(double new_temp,
 }
 
 void Refine::SetCoeff() {
-  t0_ = 4.7369E-9;
-  t1_ = -1.08337E-5;
-  t2_ = 0.008069;
-  t3_ = -0.9726;
-  p0_ = -7.17631E-10;
-  p1_ = 4.04545E-07;
-  p2_ = -8.06336E-05;
-  p3_ = 1.002;
-  a0_ = 0.032;
-  a1_ = 0.72;
-  a2_ = 0.0338396;
-  a3_ = 0.83667;
+  therm.push_back(4.7369E-9);
+  therm.push_back(-1.08337E-5);
+  therm.push_back(0.008069);
+  therm.push_back(-0.9726);
+  pres.push_back(-7.17631E-10);
+  pres.push_back(4.04545E-07);
+  pres.push_back(-8.06336E-05);
+  pres.push_back(1.002);
+  agit.push_back(0.032);
+  agit.push_back(0.72);
+  agit.push_back(0.0338396);
+  agit.push_back(0.83667);
 }
 
 struct Refine::TerminationCondition {
     bool operator() (double min, double max)  {
-        return abs(min - max) <= 0.000001;
+        return abs(min - max) <= 1e-5;
     }
 };
 
@@ -99,7 +99,7 @@ double Refine::Thermal() {
 double Refine::Thermal(double tmp,
                        double new_eff
 ) {
-  return t0()*pow(tmp,3) + t1()*pow(tmp,2) + t2()*tmp + t3() - new_eff;
+  return therm[0]*pow(tmp,3) + therm[1]*pow(tmp,2) + therm[2]*tmp + therm[3] - new_eff;
 }
 
 double Refine::PressureEff() {
@@ -109,7 +109,7 @@ double Refine::PressureEff() {
 double Refine::PressureEff(double prs,
                            double new_eff
 ) {
-  return p0()*pow(prs, 3) + p1()*pow(prs, 2) + p2()*prs + p3() - new_eff;
+  return pres[0]*pow(prs, 3) + pres[1]*pow(prs, 2) + pres[2]*prs + pres[3] - new_eff;
 }
 
 double Refine::Agitation() {
@@ -121,9 +121,9 @@ double Refine::Agitation(double rot,
 ) {
   double agi;
   if (rot <= 1) {
-    agi = a0()*rot + a1() - new_eff;
+    agi = agit[0]*rot + agit[1] - new_eff;
   } else {
-    agi = a2()*log(rot) + a3() - new_eff;
+    agi = agit[2]*log(rot) + agit[3] - new_eff;
     if (agi > 1) {
       throw ValueError("Rotation efficiency cannot exceed 1");
     }
@@ -133,53 +133,5 @@ double Refine::Agitation(double rot,
 
 double Refine::Throughput() {
   return b_size() / Rtime();
-}
-
-double Refine::t0() {
-  return t0_;
-}
-
-double Refine::t1() {
-  return t1_;
-}
-
-double Refine::t2() {
-  return t2_;
-}
-
-double Refine::t3() {
-  return t3_;
-}
-
-double Refine::p0() {
-  return p0_;
-}
-
-double Refine::p1() {
-  return p1_;
-}
-
-double Refine::p2() {
-  return p2_;
-}
-
-double Refine::p3() {
-  return p3_;
-}
-
-double Refine::a0() {
-  return a0_;
-}
-
-double Refine::a1() {
-  return a1_;
-}
-
-double Refine::a2() {
-  return a2_;
-}
-
-double Refine::a3() {
-  return a3_;
 };
 } // namespace pyro

--- a/src/toolkit/pyroprocessing/pyre_refining.h
+++ b/src/toolkit/pyroprocessing/pyre_refining.h
@@ -28,10 +28,10 @@ public:
 
 private:
 
-  /// Coefficients derived from the following:
-  /// [1]H. Lee, J. H. Lee, S. B. Park, Y. S. Lee, E. H. Kim, and S. W. Park, 
-  ///   “Advanced Electrorefining Process at KAERI,” ATALANTE 2008, May 2008.
-  
+  // Coefficients derived from the following:
+  // [1]H. Lee, J. H. Lee, S. B. Park, Y. S. Lee, E. H. Kim, and S. W. Park, 
+  //   “Advanced Electrorefining Process at KAERI,” ATALANTE 2008, May 2008.
+
   /// Thermal Efficiency coefficients
   std::vector<double> therm;
   /// Pressure Efficiency coefficients

--- a/src/toolkit/pyroprocessing/pyre_refining.h
+++ b/src/toolkit/pyroprocessing/pyre_refining.h
@@ -28,7 +28,11 @@ public:
 
 private:
 
-  /// Thermal Efficiency coefficients - Lee et al.
+  /// Coefficients derived from the following:
+  /// [1]H. Lee, J. H. Lee, S. B. Park, Y. S. Lee, E. H. Kim, and S. W. Park, 
+  ///   “Advanced Electrorefining Process at KAERI,” ATALANTE 2008, May 2008.
+  
+  /// Thermal Efficiency coefficients
   std::vector<double> therm;
   /// Pressure Efficiency coefficients
   std::vector<double> pres;

--- a/src/toolkit/pyroprocessing/pyre_refining.h
+++ b/src/toolkit/pyroprocessing/pyre_refining.h
@@ -29,7 +29,7 @@ public:
 private:
 
   // Coefficients derived from the following:
-  // [1]H. Lee, J. H. Lee, S. B. Park, Y. S. Lee, E. H. Kim, and S. W. Park, 
+  // 1 H. Lee, J. H. Lee, S. B. Park, Y. S. Lee, E. H. Kim, and S. W. Park, 
   //   “Advanced Electrorefining Process at KAERI,” ATALANTE 2008, May 2008.
 
   /// Thermal Efficiency coefficients

--- a/src/toolkit/pyroprocessing/pyre_refining.h
+++ b/src/toolkit/pyroprocessing/pyre_refining.h
@@ -29,20 +29,11 @@ public:
 private:
 
   /// Thermal Efficiency coefficients - Lee et al.
-  double t0_;
-  double t1_;
-  double t2_;
-  double t3_;
+  std::vector<double> therm;
   /// Pressure Efficiency coefficients
-  double p0_;
-  double p1_;
-  double p2_;
-  double p3_;
+  std::vector<double> pres;
   /// Stirrer Efficiency coefficient
-  double a0_;
-  double a1_;
-  double a2_;
-  double a3_;
+  std::vector<double> agit;
 
   /// @brief sets all coefficients to their defaults
   void SetCoeff();

--- a/src/toolkit/pyroprocessing/pyre_refining.h
+++ b/src/toolkit/pyroprocessing/pyre_refining.h
@@ -28,9 +28,9 @@ public:
 
 private:
 
-  // Coefficients derived from the following:
-  // 1 H. Lee, J. H. Lee, S. B. Park, Y. S. Lee, E. H. Kim, and S. W. Park, 
-  //   “Advanced Electrorefining Process at KAERI,” ATALANTE 2008, May 2008.
+  /// Coefficients derived from the following:
+  /// H. Lee, J. H. Lee, S. B. Park, Y. S. Lee, E. H. Kim, and S. W. Park, 
+  ///   "Advanced Electrorefining Process at KAERI," ATALANTE 2008, May 2008.
 
   /// Thermal Efficiency coefficients
   std::vector<double> therm;

--- a/src/toolkit/pyroprocessing/pyre_refining.h
+++ b/src/toolkit/pyroprocessing/pyre_refining.h
@@ -142,4 +142,3 @@ private:
 };
 } // namespace pyro
 #endif // RECYCLE_SRC_PYRE_REFINING_H_
-

--- a/src/toolkit/pyroprocessing/pyre_volox.h
+++ b/src/toolkit/pyroprocessing/pyre_volox.h
@@ -49,5 +49,5 @@ class Volox : public pyro::Process {
   double Throughput();
 
 };
-} // namespace recycle
+} // namespace pyro
 #endif // RECYCLE_SRC_PYRE_VOLOX_H_

--- a/src/toolkit/pyroprocessing/pyre_volox.h
+++ b/src/toolkit/pyroprocessing/pyre_volox.h
@@ -18,9 +18,8 @@ class Volox : public pyro::Process {
 	double volox_flowrate, double volox_volume);
 
  private:
- 
   // The coefficients are derived from the following:
-  // [1]R. Jubin, “Spent Fuel Reprocessing,” Oak Ridge National Lab. (ORNL), Oak Ridge, TN (United States), 2009.
+  // 1 R. Jubin, “Spent Fuel Reprocessing,” Oak Ridge National Lab. (ORNL), Oak Ridge, TN (United States), 2009.
 
   /// @brief Temperature Coefficients
   std::vector<double> th;

--- a/src/toolkit/pyroprocessing/pyre_volox.h
+++ b/src/toolkit/pyroprocessing/pyre_volox.h
@@ -18,6 +18,8 @@ class Volox : public pyro::Process {
 	double volox_flowrate, double volox_volume);
 
  private:
+  /// The coefficients are derived from the following:
+  /// [1]R. Jubin, “Spent Fuel Reprocessing,” Oak Ridge National Lab. (ORNL), Oak Ridge, TN (United States), 2009.
 
   /// @brief Temperature Coefficients
   std::vector<double> th;

--- a/src/toolkit/pyroprocessing/pyre_volox.h
+++ b/src/toolkit/pyroprocessing/pyre_volox.h
@@ -18,8 +18,8 @@ class Volox : public pyro::Process {
 	double volox_flowrate, double volox_volume);
 
  private:
-  /// The coefficients are derived from the following:
-  /// [1]R. Jubin, “Spent Fuel Reprocessing,” Oak Ridge National Lab. (ORNL), Oak Ridge, TN (United States), 2009.
+  // The coefficients are derived from the following:
+  // [1]R. Jubin, “Spent Fuel Reprocessing,” Oak Ridge National Lab. (ORNL), Oak Ridge, TN (United States), 2009.
 
   /// @brief Temperature Coefficients
   std::vector<double> th;

--- a/src/toolkit/pyroprocessing/pyre_volox.h
+++ b/src/toolkit/pyroprocessing/pyre_volox.h
@@ -18,6 +18,7 @@ class Volox : public pyro::Process {
 	double volox_flowrate, double volox_volume);
 
  private:
+ 
   // The coefficients are derived from the following:
   // [1]R. Jubin, “Spent Fuel Reprocessing,” Oak Ridge National Lab. (ORNL), Oak Ridge, TN (United States), 2009.
 

--- a/src/toolkit/pyroprocessing/pyre_volox.h
+++ b/src/toolkit/pyroprocessing/pyre_volox.h
@@ -18,8 +18,8 @@ class Volox : public pyro::Process {
 	double volox_flowrate, double volox_volume);
 
  private:
-  // The coefficients are derived from the following:
-  // 1 R. Jubin, “Spent Fuel Reprocessing,” Oak Ridge National Lab. (ORNL), Oak Ridge, TN (United States), 2009.
+  /// The coefficients are derived from the following:
+  /// R. Jubin, "Spent Fuel Reprocessing," Oak Ridge National Lab. (ORNL), Oak Ridge, TN (United States), 2009.
 
   /// @brief Temperature Coefficients
   std::vector<double> th;

--- a/src/toolkit/pyroprocessing/pyre_winning.cc
+++ b/src/toolkit/pyroprocessing/pyre_winning.cc
@@ -8,16 +8,16 @@ namespace pyro {
 
 Winning::Winning() {
   SetCoeff();
-  current(0);
-  Rtime(0);
-  flowrate(0);
-  volume(0);
+  current(8);
+  Rtime(1);
+  flowrate(3);
+  volume(1);
 }
 
-Winning::Winning(double new_current = 8, 
-                 double new_time = 1, 
-                 double new_flowrate = 3, 
-                 double new_volume = 1
+Winning::Winning(double new_current, 
+                 double new_time, 
+                 double new_flowrate, 
+                 double new_volume
             ) 
             {
   SetCoeff();

--- a/src/toolkit/pyroprocessing/pyre_winning.h
+++ b/src/toolkit/pyroprocessing/pyre_winning.h
@@ -25,13 +25,13 @@ class Winning : public pyro::Process {
 
  private:
   /// The coefficients are derived from the following:
-  /// 1 M. M. Saleh, J. W. Weidner, B. E. El‐Anadouli, and B. G. Ateya, "Electrowinning of Nonnoble Metals 
-  ///   with Simultaneous Hydrogen Evolution at Flow‐Through Porous Electrodes III. Time Effects," 
-  ///   J. Electrochem. Soc., vol. 144, no. 3, pp. 922–927, Mar. 1997.
+  /// 1 M. M. Saleh, J. W. Weidner, B. E. El-Anadouli, and B. G. Ateya, "Electrowinning of Nonnoble Metals 
+  ///   with Simultaneous Hydrogen Evolution at Flow-Through Porous Electrodes III. Time Effects," 
+  ///   J. Electrochem. Soc., vol. 144, no. 3, pp. 922-927, Mar. 1997.
   /// 2 T.-J. Kim, G.-Y. Kim, D. Yoon, D.-H. Ahn, and S. Paek, "Development of an anode structure 
   ///   consisting of graphite tubes and a SiC shroud for the electrowinning process in 
   ///   molten salt," Journal of Radioanalytical and Nuclear Chemistry, vol. 295, no. 3, 
-  ///   pp. 1855–1859, Mar. 2013.
+  ///   pp. 1855-1859, Mar. 2013.
 
 
   /// @brief Coulombic Efficiency coefficients

--- a/src/toolkit/pyroprocessing/pyre_winning.h
+++ b/src/toolkit/pyroprocessing/pyre_winning.h
@@ -24,15 +24,15 @@ class Winning : public pyro::Process {
 	double winning_flowrate, double winning_volume);
 
  private:
-
   // The coefficients are derived from the following:
-  // [1]M. M. Saleh, J. W. Weidner, B. E. El‐Anadouli, and B. G. Ateya, “Electrowinning of Nonnoble Metals 
+  // 1 M. M. Saleh, J. W. Weidner, B. E. El‐Anadouli, and B. G. Ateya, “Electrowinning of Nonnoble Metals 
   //   with Simultaneous Hydrogen Evolution at Flow‐Through Porous Electrodes III. Time Effects,” 
   //   J. Electrochem. Soc., vol. 144, no. 3, pp. 922–927, Mar. 1997.
-  // [2]T.-J. Kim, G.-Y. Kim, D. Yoon, D.-H. Ahn, and S. Paek, “Development of an anode structure 
+  // 2 T.-J. Kim, G.-Y. Kim, D. Yoon, D.-H. Ahn, and S. Paek, “Development of an anode structure 
   //   consisting of graphite tubes and a SiC shroud for the electrowinning process in 
   //   molten salt,” Journal of Radioanalytical and Nuclear Chemistry, vol. 295, no. 3, 
   //   pp. 1855–1859, Mar. 2013.
+
 
   /// @brief Coulombic Efficiency coefficients
   std::vector<double> coul;

--- a/src/toolkit/pyroprocessing/pyre_winning.h
+++ b/src/toolkit/pyroprocessing/pyre_winning.h
@@ -16,8 +16,10 @@ class Winning : public pyro::Process {
 
  public:
 
+  /// @brief default constructor
   Winning();
 
+  /// @brief overloaded constructor
   Winning(double winning_current, double winning_time, 
 	double winning_flowrate, double winning_volume);
 
@@ -50,5 +52,5 @@ class Winning : public pyro::Process {
 
   double Throughput();
 };
-} // namespace recycle
+} // namespace pyro
 #endif // RECYCLE_SRC_PYRE_WINNING_H_

--- a/src/toolkit/pyroprocessing/pyre_winning.h
+++ b/src/toolkit/pyroprocessing/pyre_winning.h
@@ -24,6 +24,7 @@ class Winning : public pyro::Process {
 	double winning_flowrate, double winning_volume);
 
  private:
+
   // The coefficients are derived from the following:
   // [1]M. M. Saleh, J. W. Weidner, B. E. El‐Anadouli, and B. G. Ateya, “Electrowinning of Nonnoble Metals 
   //   with Simultaneous Hydrogen Evolution at Flow‐Through Porous Electrodes III. Time Effects,” 
@@ -32,7 +33,6 @@ class Winning : public pyro::Process {
   //   consisting of graphite tubes and a SiC shroud for the electrowinning process in 
   //   molten salt,” Journal of Radioanalytical and Nuclear Chemistry, vol. 295, no. 3, 
   //   pp. 1855–1859, Mar. 2013.
-
 
   /// @brief Coulombic Efficiency coefficients
   std::vector<double> coul;

--- a/src/toolkit/pyroprocessing/pyre_winning.h
+++ b/src/toolkit/pyroprocessing/pyre_winning.h
@@ -32,6 +32,7 @@ class Winning : public pyro::Process {
   /// @brief Flowrate Efficiency coefficients
   std::vector<double> r;
 
+  /// @brief Sets coefficients for efficiency relationships according to literature review
   void SetCoeff();
 
   /// @brief Calculates the overall efficiency of the process by combining coulombic, temporal and flowrate effs.
@@ -50,6 +51,7 @@ class Winning : public pyro::Process {
   /// @return a value between 0 and 1 relating to separation efficiency
   double RateEff();
 
+  /// @brief This function determines the throughput of the given subprocess
   double Throughput();
 };
 } // namespace pyro

--- a/src/toolkit/pyroprocessing/pyre_winning.h
+++ b/src/toolkit/pyroprocessing/pyre_winning.h
@@ -24,14 +24,14 @@ class Winning : public pyro::Process {
 	double winning_flowrate, double winning_volume);
 
  private:
-  // The coefficients are derived from the following:
-  // 1 M. M. Saleh, J. W. Weidner, B. E. El‐Anadouli, and B. G. Ateya, “Electrowinning of Nonnoble Metals 
-  //   with Simultaneous Hydrogen Evolution at Flow‐Through Porous Electrodes III. Time Effects,” 
-  //   J. Electrochem. Soc., vol. 144, no. 3, pp. 922–927, Mar. 1997.
-  // 2 T.-J. Kim, G.-Y. Kim, D. Yoon, D.-H. Ahn, and S. Paek, “Development of an anode structure 
-  //   consisting of graphite tubes and a SiC shroud for the electrowinning process in 
-  //   molten salt,” Journal of Radioanalytical and Nuclear Chemistry, vol. 295, no. 3, 
-  //   pp. 1855–1859, Mar. 2013.
+  /// The coefficients are derived from the following:
+  /// 1 M. M. Saleh, J. W. Weidner, B. E. El‐Anadouli, and B. G. Ateya, "Electrowinning of Nonnoble Metals 
+  ///   with Simultaneous Hydrogen Evolution at Flow‐Through Porous Electrodes III. Time Effects," 
+  ///   J. Electrochem. Soc., vol. 144, no. 3, pp. 922–927, Mar. 1997.
+  /// 2 T.-J. Kim, G.-Y. Kim, D. Yoon, D.-H. Ahn, and S. Paek, "Development of an anode structure 
+  ///   consisting of graphite tubes and a SiC shroud for the electrowinning process in 
+  ///   molten salt," Journal of Radioanalytical and Nuclear Chemistry, vol. 295, no. 3, 
+  ///   pp. 1855–1859, Mar. 2013.
 
 
   /// @brief Coulombic Efficiency coefficients

--- a/src/toolkit/pyroprocessing/pyre_winning.h
+++ b/src/toolkit/pyroprocessing/pyre_winning.h
@@ -24,6 +24,15 @@ class Winning : public pyro::Process {
 	double winning_flowrate, double winning_volume);
 
  private:
+  /// The coefficients are derived from the following:
+  /// [1]M. M. Saleh, J. W. Weidner, B. E. El‐Anadouli, and B. G. Ateya, “Electrowinning of Nonnoble Metals 
+  ///   with Simultaneous Hydrogen Evolution at Flow‐Through Porous Electrodes III. Time Effects,” 
+  ///   J. Electrochem. Soc., vol. 144, no. 3, pp. 922–927, Mar. 1997.
+  /// [2]T.-J. Kim, G.-Y. Kim, D. Yoon, D.-H. Ahn, and S. Paek, “Development of an anode structure 
+  ///   consisting of graphite tubes and a SiC shroud for the electrowinning process in 
+  ///   molten salt,” Journal of Radioanalytical and Nuclear Chemistry, vol. 295, no. 3, 
+  ///   pp. 1855–1859, Mar. 2013.
+
 
   /// @brief Coulombic Efficiency coefficients
   std::vector<double> coul;

--- a/src/toolkit/pyroprocessing/pyre_winning.h
+++ b/src/toolkit/pyroprocessing/pyre_winning.h
@@ -24,14 +24,14 @@ class Winning : public pyro::Process {
 	double winning_flowrate, double winning_volume);
 
  private:
-  /// The coefficients are derived from the following:
-  /// [1]M. M. Saleh, J. W. Weidner, B. E. El‐Anadouli, and B. G. Ateya, “Electrowinning of Nonnoble Metals 
-  ///   with Simultaneous Hydrogen Evolution at Flow‐Through Porous Electrodes III. Time Effects,” 
-  ///   J. Electrochem. Soc., vol. 144, no. 3, pp. 922–927, Mar. 1997.
-  /// [2]T.-J. Kim, G.-Y. Kim, D. Yoon, D.-H. Ahn, and S. Paek, “Development of an anode structure 
-  ///   consisting of graphite tubes and a SiC shroud for the electrowinning process in 
-  ///   molten salt,” Journal of Radioanalytical and Nuclear Chemistry, vol. 295, no. 3, 
-  ///   pp. 1855–1859, Mar. 2013.
+  // The coefficients are derived from the following:
+  // [1]M. M. Saleh, J. W. Weidner, B. E. El‐Anadouli, and B. G. Ateya, “Electrowinning of Nonnoble Metals 
+  //   with Simultaneous Hydrogen Evolution at Flow‐Through Porous Electrodes III. Time Effects,” 
+  //   J. Electrochem. Soc., vol. 144, no. 3, pp. 922–927, Mar. 1997.
+  // [2]T.-J. Kim, G.-Y. Kim, D. Yoon, D.-H. Ahn, and S. Paek, “Development of an anode structure 
+  //   consisting of graphite tubes and a SiC shroud for the electrowinning process in 
+  //   molten salt,” Journal of Radioanalytical and Nuclear Chemistry, vol. 295, no. 3, 
+  //   pp. 1855–1859, Mar. 2013.
 
 
   /// @brief Coulombic Efficiency coefficients


### PR DESCRIPTION
This PR aims to clean up default constructors such that appropriate default values are used. 
Default values are also taken out of the overloaded constructor such that inputs are no longer optional.